### PR TITLE
Add aria-label to icon-only buttons

### DIFF
--- a/satisfies.js
+++ b/satisfies.js
@@ -1,0 +1,10 @@
+const Range = require('../classes/range')
+const satisfies = (version, range, options) => {
+  try {
+    range = new Range(range, options)
+  } catch (er) {
+    return false
+  }
+  return range.test(version)
+}
+module.exports = satisfies


### PR DESCRIPTION
Icon-only buttons currently lack accessible names, causing screen readers to announce nothing; this improves a11y. Update the IconButton component to accept/require an aria-label, update usages and stories, and add unit/accessibility tests to validate behavior.